### PR TITLE
Update to Ruby 2.6.5

### DIFF
--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.4
-ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+ENV RUBY_VERSION 2.6.5
+ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/centos/7/Dockerfile
+++ b/centos/7/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/local/etc \
 
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.5
-ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
+ENV RUBY_DOWNLOAD_SHA256 d5d6da717fd48524596f9b78ac5a2eeb9691753da5c06923a6c31190abe01a62
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15
+FROM centos:8
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
@@ -12,32 +12,28 @@ ENV RUBY_VERSION 2.6.5
 ENV RUBY_DOWNLOAD_SHA256 d5d6da717fd48524596f9b78ac5a2eeb9691753da5c06923a6c31190abe01a62
 
 # some of ruby's build scripts are written in ruby
-# we purge system ruby later to make sure our final image uses what we just built
+#   we purge system ruby later to make sure our final image uses what we just built
 RUN set -ex \
 	\
-  && groupadd nobody -g 99 \
-  && useradd nobody -c Nobody -u 99 -g 99 -s /sbin/nologin \
 	&& BaseDeps=' \
-    git-core \
-    gcc \
+    git \
+    wget \
+    curl \
     make \
-    automake \
-    libyaml-devel \
-    ncurses-devel \
+    gcc \
+    gcc-c++ \
+    openssl-devel \
     readline-devel \
     zlib-devel \
-    libopenssl-devel \
-    wget \
+    which \
     bison \
+    autoconf \
     patch \
     libtool \
     automake \
-    curl \
-    xz \
-    which \
-    hostname \
+    net-tools \
 	' \
-	&& zypper install -y $BaseDeps ruby \
+	&& dnf install -y $BaseDeps ruby\
 	\
 	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
@@ -64,7 +60,7 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
-	&& zypper remove -y ruby \
+	&& dnf remove -y ruby \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
 # rough smoke test

--- a/fedora/22/Dockerfile
+++ b/fedora/22/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.4
-ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+ENV RUBY_VERSION 2.6.5
+ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/fedora/22/Dockerfile
+++ b/fedora/22/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/local/etc \
 
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.5
-ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
+ENV RUBY_DOWNLOAD_SHA256 d5d6da717fd48524596f9b78ac5a2eeb9691753da5c06923a6c31190abe01a62
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/fedora/latest/Dockerfile
+++ b/fedora/latest/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.4
-ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+ENV RUBY_VERSION 2.6.5
+ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/fedora/latest/Dockerfile
+++ b/fedora/latest/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/local/etc \
 
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.5
-ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
+ENV RUBY_DOWNLOAD_SHA256 d5d6da717fd48524596f9b78ac5a2eeb9691753da5c06923a6c31190abe01a62
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/opensuse/15/Dockerfile
+++ b/opensuse/15/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.4
-ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+ENV RUBY_VERSION 2.6.5
+ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 
 # some of ruby's build scripts are written in ruby
 # we purge system ruby later to make sure our final image uses what we just built

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /usr/local/etc \
 	} >> /usr/local/etc/gemrc
 
 ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.4
-ENV RUBY_DOWNLOAD_SHA256 df593cd4c017de19adf5d0154b8391bb057cef1b72ecdd4a8ee30d3235c65f09
+ENV RUBY_VERSION 2.6.5
+ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/ubuntu/18.04/Dockerfile
+++ b/ubuntu/18.04/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /usr/local/etc \
 
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.5
-ENV RUBY_DOWNLOAD_SHA256 66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d
+ENV RUBY_DOWNLOAD_SHA256 d5d6da717fd48524596f9b78ac5a2eeb9691753da5c06923a6c31190abe01a62
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built


### PR DESCRIPTION
CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication
2019-10-01
CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
2019-10-01
CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix)
2019-10-01
CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test
2019-10-01

Signed-off-by: Tim Smith <tsmith@chef.io>