### PR TITLE
Add Windows 2019 Support

### DIFF
--- a/2.6/windows/2019/Dockerfile
+++ b/2.6/windows/2019/Dockerfile
@@ -1,0 +1,30 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=true `
+    GIT_DISCOVERY_ACROSS_FILESYSTEM=true
+
+# When launched by user, default to PowerShell if no other command specified.
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+
+# Install Chocolatey (and essentials)
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && `
+    C:\ProgramData\Chocolatey\bin\refreshenv && `
+    choco feature enable -n=allowGlobalConfirmation && `
+    choco config set cacheLocation C:\chococache && `
+    choco upgrade chocolatey && `
+    choco install git && `
+    rmdir /q /s C:\chococache && `
+    echo Chocolatey install complete -- closing out layer (this can take awhile)
+
+# Install Ruby + Devkit
+RUN powershell -Command `
+  $ErrorActionPreference = 'Stop'; `
+  Write-Output 'Downloading Ruby + DevKit'; `
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.6-1/rubyinstaller-devkit-2.6.6-1-x64.exe', 'c:\\rubyinstaller-devkit-2.6.6-1-x64.exe'); `
+  Write-Output 'Installing Ruby + DevKit'; `
+  Start-Process c:\rubyinstaller-devkit-2.6.6-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby26' -Wait ; `
+  Write-Output 'Cleaning up installation'; `
+  Remove-Item c:\rubyinstaller-devkit-2.6.6-1-x64.exe -Force; `
+  Write-Output 'Closing out the layer (this can take awhile)'

--- a/2.7/windows/2019/Dockerfile
+++ b/2.7/windows/2019/Dockerfile
@@ -1,0 +1,30 @@
+# escape=`
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=true `
+    GIT_DISCOVERY_ACROSS_FILESYSTEM=true
+
+# When launched by user, default to PowerShell if no other command specified.
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+
+# Install Chocolatey (and essentials)
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && `
+    C:\ProgramData\Chocolatey\bin\refreshenv && `
+    choco feature enable -n=allowGlobalConfirmation && `
+    choco config set cacheLocation C:\chococache && `
+    choco upgrade chocolatey && `
+    choco install git && `
+    rmdir /q /s C:\chococache && `
+    echo Chocolatey install complete -- closing out layer (this can take awhile)
+
+# Install Ruby + Devkit
+RUN powershell -Command `
+  $ErrorActionPreference = 'Stop'; `
+  Write-Output 'Downloading Ruby + DevKit'; `
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; `
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.1-1/rubyinstaller-devkit-2.7.1-1-x64.exe', 'c:\\rubyinstaller-devkit-2.7.1-1-x64.exe'); `
+  Write-Output 'Installing Ruby + DevKit'; `
+  Start-Process c:\rubyinstaller-devkit-2.7.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby27' -Wait ; `
+  Write-Output 'Cleaning up installation'; `
+  Remove-Item c:\rubyinstaller-devkit-2.7.1-1-x64.exe -Force; `
+  Write-Output 'Closing out the layer (this can take awhile)'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rubydistros
 
-Dockerfiles for Ruby on various Linux distros
+Dockerfiles for Ruby on various Windows and Linux distros
 
 ## Why?
 
-In a perfect world your Ruby app runs on Ruby and you don't care what distro is running under the hood. Unfortunatly we don't always live in that perfect world. Sometimes it's very important that Ruby be running on a specific Linux distro. That's why we have rubydistros, which a stock Ruby installation along with compilers needed for gem installation.
+In a perfect world your Ruby app runs on Ruby and you don't care what distro is running under the hood. Unfortunatly we don't always live in that perfect world. Sometimes it's very important that Ruby be running on a specific distro. That's why we have rubydistros, which a stock Ruby installation along with compilers needed for gem installation.


### PR DESCRIPTION
## Description

This PR adds initial support for Ruby 2.6 and 2.7 based on Windows 2019.

Signed-off-by: Christopher A. Snapp <csnapp@chef.io>

## Related Issue

https://github.com/chef/chef/issues/9853

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
