### PR TITLE
IPACK-136 Revert "Install ruby 3.0 and 3.1 into C:\ruby27"

### DIFF
--- a/3.0/windows/2019/Dockerfile
+++ b/3.0/windows/2019/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.2-1/rubyinstaller-devkit-3.0.2-1-x64.exe', 'c:\\rubyinstaller-devkit-3.0.2-1-x64.exe'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.0.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby27' -Wait ; \
+  Start-Process c:\rubyinstaller-devkit-3.0.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby30' -Wait ; \
   Write-Output 'Cleaning up installation'; \
   Remove-Item c:\rubyinstaller-devkit-3.0.2-1-x64.exe -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -23,7 +23,7 @@ RUN powershell -Command \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby27' -Wait ; \
+  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \
   Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';


### PR DESCRIPTION
Revert "Install ruby 3.0 and 3.1 into C:\ruby27"

This reverts commit 3bee5415f89b684623eee1181a910966b2510687.

We fixed the tests that were pointing to the wrong directory.