### PR TITLE
Add a Windows 2022 full image for 3.0 and 3.1

### DIFF
--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -5,25 +5,34 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Set-ExecutionPolicy Bypass
+
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
+RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
-  C:\ProgramData\Chocolatey\bin\refreshenv && \
-  choco feature enable -n=allowGlobalConfirmation && \
-  choco config set cacheLocation C:\chococache && \
-  choco upgrade chocolatey && \
-  choco install git && \
-  rmdir /q /s C:\chococache && \
-  echo Chocolatey install complete -- closing out layer (this can take awhile)
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+
+RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco config set cacheLocation C:\chococache
+RUN choco upgrade chocolatey
+RUN choco install git
+RUN Remove-Item -Recurse -Force c:\chococache
+
+ARG RUBY_URL=https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.6-1/rubyinstaller-3.0.6-1-x64.exe
+ARG RUBY_FILE=rubyinstaller-3.0.6-1-x64.exe
 
 # Install Ruby + Devkit
-RUN powershell -Command \
-  $ErrorActionPreference = 'Stop'; \
-  Write-Output 'Downloading Ruby + DevKit'; \
+RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.2-1/rubyinstaller-devkit-3.0.2-1-x64.exe', 'c:\\rubyinstaller-devkit-3.0.2-1-x64.exe'); \
-  Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.0.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby30' -Wait ; \
-  Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\rubyinstaller-devkit-3.0.2-1-x64.exe -Force; \
-  Write-Output 'Closing out the layer (this can take awhile)';
+  (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
+RUN Write-Output 'Installing Ruby + DevKit'
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/allusers /verysilent /dir=C:/ruby31' -Wait
+RUN Write-Output 'Cleaning up installation'
+RUN Remove-Item c:/$env:RUBY_FILE -Force
+RUN Write-Output 'Closing out the layer (this can take awhile)'
+
+

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -9,12 +9,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-#ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
-#RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
-#RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-#RUN &"$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
-#RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
-
+ENV chocolatelyVersion="1.4.0"
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-ENV chocolatelyVersion="1.4.0"
+ENV chocolateyVersion="1.4.0"
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -10,7 +10,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
-RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+#RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+RUN c:/ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
 
 # Install Chocolatey (and essentials)

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -9,8 +9,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
-RUN Start-Process ./ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
+RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -9,10 +9,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
+ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN c:/ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
-RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
+RUN $env:TEMP/$env:NET48_FILE /quiet /AcceptEULA /norestart
+RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
-RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
+RUN Start-Process ./ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
@@ -24,13 +24,15 @@ RUN Remove-Item -Recurse -Force c:\chococache
 
 ARG RUBY_URL=https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.6-1/rubyinstaller-3.0.6-1-x64.exe
 ARG RUBY_FILE=rubyinstaller-3.0.6-1-x64.exe
+ARG RUBY_DIR=c:/ruby30
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
 RUN Write-Output 'Installing Ruby + DevKit'
-RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/allusers /verysilent /dir=C:/ruby31' -Wait
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList \"/allusers /verysilent /dir=$env:RUBY_DIR\" -Wait
+
 RUN Write-Output 'Cleaning up installation'
 RUN Remove-Item c:/$env:RUBY_FILE -Force
 RUN Write-Output 'Closing out the layer (this can take awhile)'

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -12,7 +12,7 @@ RUN Set-ExecutionPolicy Bypass
 ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN $env:TEMP/$env:NET48_FILE /quiet /AcceptEULA /norestart
+RUN &"$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
 RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
 # Install Chocolatey (and essentials)

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -9,11 +9,11 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
+#ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
+#RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN &"$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
-RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
+#RUN &"$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
+#RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -11,7 +11,7 @@ RUN Set-ExecutionPolicy Bypass
 
 ENV chocolatelyVersion="1.4.0"
 # Install Chocolatey (and essentials)
-RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 RUN choco feature enable -n=allowGlobalConfirmation

--- a/3.0/windows/2019-full/Dockerfile
+++ b/3.0/windows/2019-full/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/server:ltsc2022
+FROM mcr.microsoft.com/windows:ltsc2019
 
 ENV BUNDLE_SILENCE_ROOT_WARNING=true \
     GIT_DISCOVERY_ACROSS_FILESYSTEM=true
@@ -21,9 +21,9 @@ RUN powershell -Command \
   $ErrorActionPreference = 'Stop'; \
   Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.2-1/rubyinstaller-devkit-3.0.2-1-x64.exe', 'c:\\rubyinstaller-devkit-3.0.2-1-x64.exe'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Start-Process c:\rubyinstaller-devkit-3.0.2-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby30' -Wait ; \
   Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
+  Remove-Item c:\rubyinstaller-devkit-3.0.2-1-x64.exe -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';

--- a/3.0/windows/2019/Dockerfile
+++ b/3.0/windows/2019/Dockerfile
@@ -6,6 +6,8 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
+ENV chocolatelyVersion="1.4.0"
+
 # Install Chocolatey (and essentials)
 RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
   C:\ProgramData\Chocolatey\bin\refreshenv && \

--- a/3.0/windows/2019/Dockerfile
+++ b/3.0/windows/2019/Dockerfile
@@ -6,7 +6,7 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
-ENV chocolatelyVersion="1.4.0"
+ENV chocolateyVersion="1.4.0"
 
 # Install Chocolatey (and essentials)
 RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))" && \

--- a/3.0/windows/2019/Dockerfile
+++ b/3.0/windows/2019/Dockerfile
@@ -9,7 +9,7 @@ CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 ENV chocolatelyVersion="1.4.0"
 
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))" && \
   C:\ProgramData\Chocolatey\bin\refreshenv && \
   choco feature enable -n=allowGlobalConfirmation && \
   choco config set cacheLocation C:\chococache && \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -7,12 +7,14 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
+
 RUN Set-ExecutionPolicy Bypass
 
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
+ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN c:/ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
-RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
+RUN $env:TEMP/$env:NET48_FILE /quiet /AcceptEULA /norestart
+RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -15,7 +15,6 @@ RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-#RUN C:\ProgramData\Chocolatey\bin\refreshenv
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco config set cacheLocation C:\chococache

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -31,7 +31,7 @@ RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
 RUN Write-Output 'Installing Ruby + DevKit'
-RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/verysilent /dir=C:/ruby31' -Wait
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/allusers /verysilent /dir=C:/ruby31' -Wait
 RUN Write-Output 'Cleaning up installation'
 RUN Remove-Item c:/$env:RUBY_FILE -Force
 RUN Write-Output 'Closing out the layer (this can take awhile)'

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -15,7 +15,8 @@ RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-RUN C:\ProgramData\Chocolatey\bin\refreshenv
+#RUN C:\ProgramData\Chocolatey\bin\refreshenv
+RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco config set cacheLocation C:\chococache
 RUN choco upgrade chocolatey

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,14 +10,14 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 # Install Chocolatey (and essentials)
-RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) && \
-  C:\ProgramData\Chocolatey\bin\refreshenv && \
-  choco feature enable -n=allowGlobalConfirmation && \
-  choco config set cacheLocation C:\chococache && \
-  choco upgrade chocolatey && \
-  choco install git && \
-  rmdir /q /s C:\chococache && \
-  echo Chocolatey install complete -- closing out layer (this can take awhile)
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN C:\ProgramData\Chocolatey\bin\refreshenv
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco config set cacheLocation C:\chococache
+RUN choco upgrade chocolatey
+RUN choco install git
+RUN rmdir /q /s C:\chococache
+RUN echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/windows:ltsc2019
+#FROM mcr.microsoft.com/windows:ltsc2019
+FROM mcr.microsoft.com/windows:1809-KB5035849
 
 ENV BUNDLE_SILENCE_ROOT_WARNING=true \
     GIT_DISCOVERY_ACROSS_FILESYSTEM=true

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -15,9 +15,9 @@ ENV chocolateyVersion="1.4.0"
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-RUN choco feature enable -n=allowGlobalConfirmation
-RUN choco config set cacheLocation C:\chococache
-RUN choco upgrade chocolatey
+#RUN choco feature enable -n=allowGlobalConfirmation
+#RUN choco config set cacheLocation C:\chococache
+#RUN choco upgrade chocolatey
 RUN choco install git
 RUN Remove-Item -Recurse -Force c:\chococache
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
-RUN ndp48-x86-x64-allos-enu.exe
+RUN .\ndp48-x86-x64-allos-enu.exe
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -21,7 +21,7 @@ RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco config set cacheLocation C:\chococache
 RUN choco upgrade chocolatey
 RUN choco install git
-RUN rmdir /q /s C:\chococache
+RUN Remove-Item -Recurse -Force c:\chococache
 RUN echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -1,14 +1,16 @@
-#FROM mcr.microsoft.com/windows:ltsc2019
-FROM mcr.microsoft.com/windows:1809-KB5035849
+FROM mcr.microsoft.com/windows:ltsc2019
 
 ENV BUNDLE_SILENCE_ROOT_WARNING=true \
     GIT_DISCOVERY_ACROSS_FILESYSTEM=true
 
 # When launched by user, default to PowerShell if no other command specified.
-RUN ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Set-ExecutionPolicy Bypass
 
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) && \
   C:\ProgramData\Chocolatey\bin\refreshenv && \
   choco feature enable -n=allowGlobalConfirmation && \
   choco config set cacheLocation C:\chococache && \
@@ -18,9 +20,7 @@ RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).Do
   echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit
-RUN powershell -Command \
-  $ErrorActionPreference = 'Stop'; \
-  Write-Output 'Downloading Ruby + DevKit'; \
+RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
   Write-Output 'Installing Ruby + DevKit'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -22,7 +22,6 @@ RUN choco config set cacheLocation C:\chococache
 RUN choco upgrade chocolatey
 RUN choco install git
 RUN Remove-Item -Recurse -Force c:\chococache
-RUN echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -29,10 +29,10 @@ ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('#{RUBY_URL}', 'c:\\#{RUBY_FILE}'); \
+  (New-Object System.Net.WebClient).DownloadFile('${RUBY_URL}', 'c:\\${RUBY_FILE}'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\#{RUBY_FILE} -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Start-Process c:\${RUBY_FILE} -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\#{RUBY_FILE} -Force; \
+  Remove-Item c:\${RUBY_FILE} -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/windows:ltsc2019
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=true \
+    GIT_DISCOVERY_ACROSS_FILESYSTEM=true
+
+# When launched by user, default to PowerShell if no other command specified.
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+
+# Install Chocolatey (and essentials)
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
+  C:\ProgramData\Chocolatey\bin\refreshenv && \
+  choco feature enable -n=allowGlobalConfirmation && \
+  choco config set cacheLocation C:\chococache && \
+  choco upgrade chocolatey && \
+  choco install git && \
+  rmdir /q /s C:\chococache && \
+  echo Chocolatey install complete -- closing out layer (this can take awhile)
+
+# Install Ruby + Devkit
+RUN powershell -Command \
+  $ErrorActionPreference = 'Stop'; \
+  Write-Output 'Downloading Ruby + DevKit'; \
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
+  Write-Output 'Installing Ruby + DevKit'; \
+  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Write-Output 'Cleaning up installation'; \
+  Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
+  Write-Output 'Closing out the layer (this can take awhile)';

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -29,7 +29,7 @@ ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('${RUBY_URL}', 'c:\\${RUBY_FILE}'); \
+  (New-Object System.Net.WebClient).DownloadFile("${RUBY_URL}", "c:\\${RUBY_FILE}"); \
   Write-Output 'Installing Ruby + DevKit'; \
   Start-Process c:\${RUBY_FILE} -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -15,8 +15,8 @@ ENV chocolateyVersion="1.4.0"
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-#RUN choco feature enable -n=allowGlobalConfirmation
-#RUN choco config set cacheLocation C:\chococache
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco config set cacheLocation C:\chococache
 #RUN choco upgrade chocolatey
 RUN choco install git
 RUN Remove-Item -Recurse -Force c:\chococache

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -9,15 +9,19 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
+RUN ndp48-x86-x64-allos-enu.exe
+
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-RUN C:\ProgramData\Chocolatey\bin\refreshenv
-RUN choco feature enable -n=allowGlobalConfirmation
-RUN choco config set cacheLocation C:\chococache
-RUN choco upgrade chocolatey
-RUN choco install git
-RUN rmdir /q /s C:\chococache
-RUN echo Chocolatey install complete -- closing out layer (this can take awhile)
+
+RUN C:\ProgramData\Chocolatey\bin\refreshenv && \
+  choco feature enable -n=allowGlobalConfirmation && \
+  choco config set cacheLocation C:\chococache && \
+  choco upgrade chocolatey && \
+  choco install git && \
+  rmdir /q /s C:\chococache && \
+  echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -29,10 +29,10 @@ ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile("${RUBY_URL}", "c:\\${RUBY_FILE}"); \
+  (New-Object System.Net.WebClient).DownloadFile("$env:RUBY_URL", "c:/$env:RUBY_FILE"); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\${RUBY_FILE} -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Start-Process c:/$env:RUBY_FILE -ArgumentList '/verysilent /dir=C:/ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\${RUBY_FILE} -Force; \
+  Remove-Item c:/$env:RUBY_FILE -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,7 +10,8 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
-RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+#RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+RUN c:/ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
 
 # Install Chocolatey (and essentials)

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -29,10 +29,10 @@ ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile("$env:RUBY_URL", "c:/$env:RUBY_FILE"); \
-  Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:/$env:RUBY_FILE -ArgumentList '/verysilent /dir=C:/ruby31' -Wait ; \
-  Write-Output 'Cleaning up installation'; \
-  Remove-Item c:/$env:RUBY_FILE -Force; \
-  Write-Output 'Closing out the layer (this can take awhile)';
+  (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
+RUN Write-Output 'Installing Ruby + DevKit'
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/verysilent /dir=C:/ruby31' -Wait
+RUN Write-Output 'Cleaning up installation'
+RUN Remove-Item c:/$env:RUBY_FILE -Force
+RUN Write-Output 'Closing out the layer (this can take awhile)'
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,12 +10,13 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
+#ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
+#RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN & "$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
-RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
+#RUN & "$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
+#RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
+ENV chocolateyVersion="1.4.0"
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -23,12 +23,16 @@ RUN choco upgrade chocolatey
 RUN choco install git
 RUN Remove-Item -Recurse -Force c:\chococache
 
+ARG RUBY_URL=https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.4-1/rubyinstaller-3.1.4-1-x64.exe
+ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
+
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
+  (New-Object System.Net.WebClient).DownloadFile('#{RUBY_URL}', 'c:\\#{RUBY_FILE}'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Start-Process c:\#{RUBY_FILE} -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
+  Remove-Item c:\#{RUBY_FILE} -Force; \
   Write-Output 'Closing out the layer (this can take awhile)';
+

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -4,7 +4,7 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
     GIT_DISCOVERY_ACROSS_FILESYSTEM=true
 
 # When launched by user, default to PowerShell if no other command specified.
-CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+RUN ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
 # Install Chocolatey (and essentials)
 RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 RUN Set-ExecutionPolicy Bypass
 
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
-RUN .\ndp48-x86-x64-allos-enu.exe
+RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -13,7 +13,7 @@ RUN Set-ExecutionPolicy Bypass
 ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
 RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
 #RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-RUN $env:TEMP/$env:NET48_FILE /quiet /AcceptEULA /norestart
+RUN & "$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
 RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
 
 # Install Chocolatey (and essentials)

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -10,12 +10,6 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-#ARG NET48_FILE=ndp48-x86-x64-allos-enu.exe
-#RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/$env:NET48_FILE -OutFile $env:TEMP/$env:NET48_FILE
-#RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
-#RUN & "$env:TEMP/$env:NET48_FILE" /quiet /AcceptEULA /norestart
-#RUN Remove-Item -Force $env:TEMP/$env:NET48_FILE
-
 ENV chocolateyVersion="1.4.0"
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -15,13 +15,13 @@ RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
-RUN C:\ProgramData\Chocolatey\bin\refreshenv && \
-  choco feature enable -n=allowGlobalConfirmation && \
-  choco config set cacheLocation C:\chococache && \
-  choco upgrade chocolatey && \
-  choco install git && \
-  rmdir /q /s C:\chococache && \
-  echo Chocolatey install complete -- closing out layer (this can take awhile)
+RUN C:\ProgramData\Chocolatey\bin\refreshenv
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco config set cacheLocation C:\chococache
+RUN choco upgrade chocolatey
+RUN choco install git
+RUN rmdir /q /s C:\chococache
+RUN echo Chocolatey install complete -- closing out layer (this can take awhile)
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -9,8 +9,9 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 RUN Set-ExecutionPolicy Bypass
 
-RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile ndp48-x86-x64-allos-enu.exe
-RUN .\ndp48-x86-x64-allos-enu.exe /quiet /AcceptEULA /norestart
+RUN Invoke-WebRequest https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe -OutFile c:/ndp48-x86-x64-allos-enu.exe
+RUN Start-Process c:/ndp48-x86-x64-allos-enu.exe -ArgumentList '/quiet /AcceptEULA /norestart' -Wait
+RUN Remove-Item -Force c:/ndp48-x86-x64-allos-enu.exe
 
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -17,7 +17,6 @@ RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https:/
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 RUN choco feature enable -n=allowGlobalConfirmation
 RUN choco config set cacheLocation C:\chococache
-#RUN choco upgrade chocolatey
 RUN choco install git
 RUN Remove-Item -Recurse -Force c:\chococache
 

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -12,7 +12,7 @@ RUN Set-ExecutionPolicy Bypass
 
 ENV chocolateyVersion="1.4.0"
 # Install Chocolatey (and essentials)
-RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
 RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 RUN choco feature enable -n=allowGlobalConfirmation

--- a/3.1/windows/2019-full/Dockerfile
+++ b/3.1/windows/2019-full/Dockerfile
@@ -24,13 +24,14 @@ RUN Remove-Item -Recurse -Force c:\chococache
 
 ARG RUBY_URL=https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.4-1/rubyinstaller-3.1.4-1-x64.exe
 ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
+ARG RUBY_DIR=c:/ruby30
 
 # Install Ruby + Devkit
 RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
   (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
 RUN Write-Output 'Installing Ruby + DevKit'
-RUN Start-Process c:/$env:RUBY_FILE -ArgumentList '/allusers /verysilent /dir=C:/ruby31' -Wait
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList \"/allusers /verysilent /dir=$env:RUBY_DIR\" -Wait
 RUN Write-Output 'Cleaning up installation'
 RUN Remove-Item c:/$env:RUBY_FILE -Force
 RUN Write-Output 'Closing out the layer (this can take awhile)'

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -6,6 +6,8 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
+ENV chocolatelyVersion="1.4.0"
+
 # Install Chocolatey (and essentials)
 RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
   C:\ProgramData\Chocolatey\bin\refreshenv && \

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -7,7 +7,8 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV chocolatelyVersion="1.4.0"
+ENV chocolateyVersion="1.4.0"
+
 # Install Chocolatey (and essentials)
 RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -9,7 +9,7 @@ CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 ENV chocolatelyVersion="1.4.0"
 
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))" && \
   C:\ProgramData\Chocolatey\bin\refreshenv && \
   choco feature enable -n=allowGlobalConfirmation && \
   choco config set cacheLocation C:\chococache && \

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -5,27 +5,29 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 ENV chocolatelyVersion="1.4.0"
-
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))" && \
-  C:\ProgramData\Chocolatey\bin\refreshenv && \
-  choco feature enable -n=allowGlobalConfirmation && \
-  choco config set cacheLocation C:\chococache && \
-  choco upgrade chocolatey && \
-  choco install git && \
-  rmdir /q /s C:\chococache && \
-  echo Chocolatey install complete -- closing out layer (this can take awhile)
+RUN Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+RUN Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+RUN choco feature enable -n=allowGlobalConfirmation
+RUN choco config set cacheLocation C:\chococache
+RUN choco install git
+RUN Remove-Item -Recurse -Force c:\chococache
+
+ARG RUBY_URL=https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.4-1/rubyinstaller-3.1.4-1-x64.exe
+ARG RUBY_FILE=rubyinstaller-3.1.4-1-x64.exe
+ARG RUBY_DIR=c:/ruby30
 
 # Install Ruby + Devkit
-RUN powershell -Command \
-  $ErrorActionPreference = 'Stop'; \
-  Write-Output 'Downloading Ruby + DevKit'; \
+RUN Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
-  Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
-  Write-Output 'Cleaning up installation'; \
-  Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
-  Write-Output 'Closing out the layer (this can take awhile)';
+  (New-Object System.Net.WebClient).DownloadFile(\"$env:RUBY_URL\", \"c:/$env:RUBY_FILE\")
+RUN Write-Output 'Installing Ruby + DevKit'
+RUN Start-Process c:/$env:RUBY_FILE -ArgumentList \"/allusers /verysilent /dir=$env:RUBY_DIR\" -Wait
+RUN Write-Output 'Cleaning up installation'
+RUN Remove-Item c:/$env:RUBY_FILE -Force
+RUN Write-Output 'Closing out the layer (this can take awhile)'
+

--- a/3.1/windows/2022-full/Dockerfile
+++ b/3.1/windows/2022-full/Dockerfile
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/windows/server:ltsc2022
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=true \
+    GIT_DISCOVERY_ACROSS_FILESYSTEM=true
+
+# When launched by user, default to PowerShell if no other command specified.
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+
+# Install Chocolatey (and essentials)
+RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
+  C:\ProgramData\Chocolatey\bin\refreshenv && \
+  choco feature enable -n=allowGlobalConfirmation && \
+  choco config set cacheLocation C:\chococache && \
+  choco upgrade chocolatey && \
+  choco install git && \
+  rmdir /q /s C:\chococache && \
+  echo Chocolatey install complete -- closing out layer (this can take awhile)
+
+# Install Ruby + Devkit
+RUN powershell -Command \
+  $ErrorActionPreference = 'Stop'; \
+  Write-Output 'Downloading Ruby + DevKit'; \
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
+  Write-Output 'Installing Ruby + DevKit'; \
+  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Write-Output 'Cleaning up installation'; \
+  Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
+  Write-Output 'Closing out the layer (this can take awhile)';

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -1,11 +1,5 @@
 ---
 # Alma
-image=2_6-almalinux-8:
-  image: '{env.IMAGE_REGISTRY}/almalinux-8'
-  context: 2.6/almalinux/8
-  tags:
-    - '2.6'
-
 image=2_7-almalinux-8:
   image: '{env.IMAGE_REGISTRY}/almalinux-8'
   context: 2.7/almalinux/8
@@ -26,18 +20,6 @@ image=3_1-almalinux-8:
     - '3.1'
 
 # Centos
-image=2_6-centos-7:
-  image: '{env.IMAGE_REGISTRY}/centos-7'
-  context: 2.6/centos/7
-  tags:
-    - '2.6'
-
-image=2_6-centos-8:
-  image: '{env.IMAGE_REGISTRY}/centos-8'
-  context: 2.6/centos/8
-  tags:
-    - '2.6'
-
 image=2_7-centos-7:
   image: '{env.IMAGE_REGISTRY}/centos-7'
   context: 2.7/centos/7
@@ -77,18 +59,6 @@ image=3_1-centos-8:
     - '3.1'
 
 # Fedora
-image=2_6-fedora-22:
-  image: '{env.IMAGE_REGISTRY}/fedora-22'
-  context: 2.6/fedora/22
-  tags:
-    - '2.6'
-
-image=2_6-fedora-latest:
-  image: '{env.IMAGE_REGISTRY}/fedora-latest'
-  context: 2.6/fedora/latest
-  tags:
-    - '2.6'
-
 image=2_7-fedora-22:
   image: '{env.IMAGE_REGISTRY}/fedora-22'
   context: 2.7/fedora/22
@@ -129,12 +99,6 @@ image=3_1-fedora-latest:
 
 
 # Opensuse
-image=2_6-opensuse-15:
-  image: '{env.IMAGE_REGISTRY}/opensuse-15'
-  context: 2.6/opensuse/15
-  tags:
-    - '2.6'
-
 image=2_7-opensuse-15:
   image: '{env.IMAGE_REGISTRY}/opensuse-15'
   context: 2.7/opensuse/15
@@ -155,24 +119,6 @@ image=3_1-opensuse-15:
     - '3.1'
 
 # Ubuntu
-image=2_6-ubuntu-18_04:
-  image: '{env.IMAGE_REGISTRY}/ubuntu-18.04'
-  context: 2.6/ubuntu/18.04
-  tags:
-    - '2.6'
-
-image=2_6-ubuntu-20_04:
-  image: '{env.IMAGE_REGISTRY}/ubuntu-20.04'
-  context: 2.6/ubuntu/20.04
-  tags:
-    - '2.6'
-
-image=2_6-ubuntu-22_04:
-  image: '{env.IMAGE_REGISTRY}/ubuntu-22.04'
-  context: 2.6/ubuntu/22.04
-  tags:
-    - '2.6'
-
 image=2_7-ubuntu-18_04:
   image: '{env.IMAGE_REGISTRY}/ubuntu-18.04'
   context: 2.7/ubuntu/18.04
@@ -231,15 +177,6 @@ image=3_1-ubuntu-22_04:
     - '3.1'
 
 # Windows
-image=2_6-windows-2019:
-  image: '{env.IMAGE_REGISTRY}/windows-2019'
-  context: 2.6/windows/2019
-  tags:
-    - '2.6'
-  annotations:
-    tags:
-      - expeditor:host-os=windows
-
 image=2_7-windows-2019:
   image: '{env.IMAGE_REGISTRY}/windows-2019'
   context: 2.7/windows/2019

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -65,12 +65,6 @@ image=2_7-fedora-22:
   tags:
     - '2.7'
 
-image=2_7-fedora-latest:
-  image: '{env.IMAGE_REGISTRY}/fedora-latest'
-  context: 2.7/fedora/latest
-  tags:
-    - '2.7'
-
 image=3_0-fedora-22:
   image: '{env.IMAGE_REGISTRY}/fedora-22'
   context: 3.0/fedora/22
@@ -128,12 +122,6 @@ image=2_7-ubuntu-18_04:
 image=2_7-ubuntu-20_04:
   image: '{env.IMAGE_REGISTRY}/ubuntu-20.04'
   context: 2.7/ubuntu/20.04
-  tags:
-    - '2.7'
-
-image=2_7-ubuntu-22_04:
-  image: '{env.IMAGE_REGISTRY}/ubuntu-22.04'
-  context: 2.7/ubuntu/22.04
   tags:
     - '2.7'
 

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -258,6 +258,16 @@ image=3_0-windows-2019:
     tags:
       - expeditor:host-os=windows
 
+image=3_0-windows-2022-full:
+  image: '{env.IMAGE_REGISTRY}/windows-2022-full'
+  context: 3.0/windows/2022-full
+  tags:
+    - '3.0'
+    - latest
+  annotations:
+    tags:
+      - expeditor:host-os=windows
+
 image=3_1-windows-2019:
   image: '{env.IMAGE_REGISTRY}/windows-2019'
   context: 3.1/windows/2019
@@ -267,3 +277,15 @@ image=3_1-windows-2019:
   annotations:
     tags:
       - expeditor:host-os=windows
+
+image=3_1-windows-2022-full:
+  image: '{env.IMAGE_REGISTRY}/windows-2022-full'
+  context: 3.1/windows/2022-full
+  tags:
+    - '3.1'
+    - latest
+  annotations:
+    tags:
+      - expeditor:host-os=windows
+
+

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -195,9 +195,9 @@ image=3_0-windows-2019:
     tags:
       - expeditor:host-os=windows
 
-image=3_0-windows-2022-full:
-  image: '{env.IMAGE_REGISTRY}/windows-2022-full'
-  context: 3.0/windows/2022-full
+image=3_0-windows-2019-full:
+  image: '{env.IMAGE_REGISTRY}/windows-2019-full'
+  context: 3.0/windows/2019-full
   tags:
     - '3.0'
     - latest
@@ -215,9 +215,9 @@ image=3_1-windows-2019:
     tags:
       - expeditor:host-os=windows
 
-image=3_1-windows-2022-full:
-  image: '{env.IMAGE_REGISTRY}/windows-2022-full'
-  context: 3.1/windows/2022-full
+image=3_1-windows-2019-full:
+  image: '{env.IMAGE_REGISTRY}/windows-2019-full'
+  context: 3.1/windows/2019-full
   tags:
     - '3.1'
     - latest


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
https://github.com/chef/win32-service CI is broken because Windows Server 2019 Core does not have the Windows STI service and, as far as I can tell, no other services allow for all the operations under test in the test suite. There didn't appear to be a docker image attached for the previous release, so I suspect in never ran successfully.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
