### PR TITLE
create new windows pipeline for windows docker images

### DIFF
--- a/.expeditor/build_windows.docker.yml
+++ b/.expeditor/build_windows.docker.yml
@@ -1,0 +1,1 @@
+image_registry: rubydistros

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -7,8 +7,13 @@ slack:
 
 pipelines:
   - docker/build
+  - docker/build_windows:
+      definition: .expeditor/build_windows.docker.yml
 
 subscriptions:
   - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
     actions:
     - trigger_pipeline:docker/build
+    - trigger_pipeline:windows/build
+    only_if_modified:
+      - 3.3/windows/2019/Dockerfile


### PR DESCRIPTION
create new windows pipeline for windows docker images

<!--- Provide a short summary of your changes in the Title above -->

## Description
this will create a new pipeline for windows docker images which we will use for new ruby images

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
