### PR TITLE
install .NET and msys2 toolkits in ruby 3.1 docker image

### DIFF
--- a/.expeditor/build-windows-docker.yml
+++ b/.expeditor/build-windows-docker.yml
@@ -13,24 +13,24 @@ steps:
   label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.1"
   commands:
     - "docker build . -f 3.1/windows/2019/Dockerfile -t windows-2019:3.1"
-    - "docker tag windows-2019:3.1 docker.io/rubydistros/windows-2019:3.1"
-    - "docker push docker.io/rubydistros/windows-2019:3.1"
+    # - "docker tag windows-2019:3.1 docker.io/rubydistros/windows-2019:3.1"
+    # - "docker push docker.io/rubydistros/windows-2019:3.1"
   agents:
     queue: docker-windows-2019
   plugins:
     - docker-login#v2.1.0:
         username: expeditor
-        
-- id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-4
-  label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.4"
-  commands:
-    - "docker build . -f 3.4/windows/2019/Dockerfile -t windows-2019:3.4"
-    - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:3.4"
-    - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:latest"
-    - "docker push docker.io/rubydistros/windows-2019:3.4"
-    - "docker push docker.io/rubydistros/windows-2019:latest"
-  agents:
-    queue: docker-windows-2019
-  plugins:
-    - docker-login#v2.1.0:
-        username: expeditor
+
+# - id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-4
+#   label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.4"
+#   commands:
+#     - "docker build . -f 3.4/windows/2019/Dockerfile -t windows-2019:3.4"
+#     - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:3.4"
+#     - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:latest"
+#     - "docker push docker.io/rubydistros/windows-2019:3.4"
+#     - "docker push docker.io/rubydistros/windows-2019:latest"
+#   agents:
+#     queue: docker-windows-2019
+#   plugins:
+#     - docker-login#v2.1.0:
+#         username: expeditor

--- a/.expeditor/build-windows-docker.yml
+++ b/.expeditor/build-windows-docker.yml
@@ -13,24 +13,24 @@ steps:
   label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.1"
   commands:
     - "docker build . -f 3.1/windows/2019/Dockerfile -t windows-2019:3.1"
-    # - "docker tag windows-2019:3.1 docker.io/rubydistros/windows-2019:3.1"
-    # - "docker push docker.io/rubydistros/windows-2019:3.1"
+    - "docker tag windows-2019:3.1 docker.io/rubydistros/windows-2019:3.1"
+    - "docker push docker.io/rubydistros/windows-2019:3.1"
   agents:
     queue: docker-windows-2019
   plugins:
     - docker-login#v2.1.0:
         username: expeditor
-
-# - id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-4
-#   label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.4"
-#   commands:
-#     - "docker build . -f 3.4/windows/2019/Dockerfile -t windows-2019:3.4"
-#     - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:3.4"
-#     - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:latest"
-#     - "docker push docker.io/rubydistros/windows-2019:3.4"
-#     - "docker push docker.io/rubydistros/windows-2019:latest"
-#   agents:
-#     queue: docker-windows-2019
-#   plugins:
-#     - docker-login#v2.1.0:
-#         username: expeditor
+        
+- id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-4
+  label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.4"
+  commands:
+    - "docker build . -f 3.4/windows/2019/Dockerfile -t windows-2019:3.4"
+    - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:3.4"
+    - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:latest"
+    - "docker push docker.io/rubydistros/windows-2019:3.4"
+    - "docker push docker.io/rubydistros/windows-2019:latest"
+  agents:
+    queue: docker-windows-2019
+  plugins:
+    - docker-login#v2.1.0:
+        username: expeditor

--- a/.expeditor/build-windows-docker.yml
+++ b/.expeditor/build-windows-docker.yml
@@ -9,8 +9,20 @@ env:
   VERSION: 1.1.16
 
 steps:
-- id: build-and-push-on-windows-2019-server-rubydistros-dockerhub
-  label: ":docker::windows: build-and-push-rubydistros-dockerhub"
+- id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-1
+  label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.1"
+  commands:
+    - "docker build . -f 3.1/windows/2019/Dockerfile -t windows-2019:3.1"
+    - "docker tag windows-2019:3.1 docker.io/rubydistros/windows-2019:3.1"
+    - "docker push docker.io/rubydistros/windows-2019:3.1"
+  agents:
+    queue: docker-windows-2019
+  plugins:
+    - docker-login#v2.1.0:
+        username: expeditor
+        
+- id: build-and-push-on-windows-2019-server-rubydistros-dockerhub-3-4
+  label: ":docker::windows: build-and-push-rubydistros-dockerhub-3.4"
   commands:
     - "docker build . -f 3.4/windows/2019/Dockerfile -t windows-2019:3.4"
     - "docker tag windows-2019:3.4 docker.io/rubydistros/windows-2019:3.4"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -14,4 +14,4 @@ subscriptions:
   - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
     actions:
     - trigger_pipeline:docker/build
-    - trigger_pipeline:windows/build
+    - trigger_pipeline:build-windows

--- a/3.1/windows/2019/Dockerfile
+++ b/3.1/windows/2019/Dockerfile
@@ -6,24 +6,46 @@ ENV BUNDLE_SILENCE_ROOT_WARNING=true \
 # When launched by user, default to PowerShell if no other command specified.
 CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
 
+# latest choco via PowerShell on windows2019 requires .NET, Download and install .NET Framework 4.8
+FROM mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2019
+ADD https://go.microsoft.com/fwlink/?linkid=863265 /ndp472-kb4054530-x86-x64-allos-enu.exe
+RUN C:\ndp472-kb4054530-x86-x64-allos-enu.exe /quiet /install
+
 # Install Chocolatey (and essentials)
-RUN powershell -Command "Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && \
-  C:\ProgramData\Chocolatey\bin\refreshenv && \
-  choco feature enable -n=allowGlobalConfirmation && \
-  choco config set cacheLocation C:\chococache && \
-  choco upgrade chocolatey && \
-  choco install git && \
-  rmdir /q /s C:\chococache && \
-  echo Chocolatey install complete -- closing out layer (this can take awhile)
+ADD https://chocolatey.org/install.ps1 /chocolatey_install.ps1
+RUN powershell -File C:\chocolatey_install.ps1
+RUN C:\ProgramData\Chocolatey\bin\refreshenv -and \
+  choco feature enable -n=allowGlobalConfirmation -and \
+  choco config set cacheLocation C:\chococache -and \
+  choco upgrade chocolatey -and \
+  rmdir /q /s C:\chococache -and \
+  del C:\chocolatey_install.ps1 -and \
+  Write-Output "Chocolatey install complete -- closing out layer"
+#install git
+RUN choco install git.install -y
+#from the versions which are >2.35 requires Strict repository ownership checks hence we are doing this step
+#can found more on here https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks
+RUN git config --system --add safe.directory '*'
+RUN git --version  
 
 # Install Ruby + Devkit
-RUN powershell -Command \
-  $ErrorActionPreference = 'Stop'; \
+RUN $ErrorActionPreference = 'Stop'; \
   Write-Output 'Downloading Ruby + DevKit'; \
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-devkit-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
+  (New-Object System.Net.WebClient).DownloadFile('https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.1-1/rubyinstaller-3.1.1-1-x64.exe', 'c:\\rubyinstaller-devkit-3.1.1-1-x64.exe'); \
   Write-Output 'Installing Ruby + DevKit'; \
-  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /dir=C:\\ruby31' -Wait ; \
+  Start-Process c:\rubyinstaller-devkit-3.1.1-1-x64.exe -ArgumentList '/verysilent /allusers /dir=C:\\ruby31' -Wait ; \
   Write-Output 'Cleaning up installation'; \
   Remove-Item c:\rubyinstaller-devkit-3.1.1-1-x64.exe -Force; \
-  Write-Output 'Closing out the layer (this can take awhile)';
+  Write-Output 'Closing out the layer';
+
+# Download MSYS2 dev kit, extract it and add to the PATH variable
+
+RUN powershell -Command (New-Object System.Net.WebClient).DownloadFile('https://github.com/msys2/msys2-installer/releases/download/2025-02-21/msys2-x86_64-20250221.exe', 'c:\\msys2-x86_64-20250221.exe'); \
+   .\msys2-x86_64-20250221.exe in --confirm-command --accept-messages --root C:\msys2 ; \
+   [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\msys2', [EnvironmentVariableTarget]::Machine); \
+   Remove-Item 'C:\msys2-x86_64-20250221.exe'
+
+#Install MSYS2 and MINGW development toolchain and enable it
+RUN ridk install 3
+RUN ridk enable


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
current ruby 3.1 docker image is not having latest tools and libraries which are needed for our verify test cases in order to pass. eg : here we are installing .NET and mysys2 devkit tools which will enhance this ruby 3.1 image to fix knife verify test cases. PFA 1st screenshot below here in this test case its failing due to powershell dll missing which will be fixed by having .NET and msys2 dev kit . Have tested this change locally by running same test scenarios where we have seen this error is not occurring . can see in 2nd screenshot

<img width="1676" alt="Screenshot 2025-07-09 at 4 38 26 PM" src="https://github.com/user-attachments/assets/f3aa635a-3f56-40f1-a78a-f27a617882c0" />


<img width="1676" alt="Screenshot 2025-07-09 at 2 34 36 PM" src="https://github.com/user-attachments/assets/7c0d3fe5-9972-4274-8656-6fb889f974e8" />



## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
